### PR TITLE
fix: replace ModelMapper with manual mapping in RoleServiceImpl.toDto()

### DIFF
--- a/src/main/java/co/javeriana/dw/organizapp/service/impl/RoleServiceImpl.java
+++ b/src/main/java/co/javeriana/dw/organizapp/service/impl/RoleServiceImpl.java
@@ -130,9 +130,12 @@ public class RoleServiceImpl implements RoleService {
     }
 
     private RoleResponseDto toDto(Role role) {
-        RoleResponseDto dto = modelMapper.map(role, RoleResponseDto.class);
-        dto.setProcessId(role.getProceso() == null ? null : role.getProceso().getId());
+        RoleResponseDto dto = new RoleResponseDto();
+        dto.setId(role.getId());
+        dto.setNombre(role.getNombre());
+        dto.setDescripcion(role.getDescripcion());
         dto.setCompanyId(role.getCompany() == null ? null : role.getCompany().getId());
+        dto.setProcessId(role.getProceso() == null ? null : role.getProceso().getId());
         return dto;
     }
 


### PR DESCRIPTION
- Avoid LazyInitializationException with lazy-loaded entities
- Fix potential property mapping errors between Role and RoleResponseDto
- Manually construct RoleResponseDto to handle company/companyId and proceso/processId conversions
- Resolves 500 error when creating company roles with processId: null