### PR TITLE
fix: CORS para produccion (https://grupo14.inphotech.co)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: grupo14
 data:
   DB_URL: jdbc:postgresql://190.146.2.119:2345/grupo14
+  CORS_ALLOWED_ORIGINS: "http://localhost:4200,https://grupo14.inphotech.co"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -45,6 +46,11 @@ spec:
             secretKeyRef:
               name: backend-secret
               key: DB_PASSWORD
+        - name: CORS_ALLOWED_ORIGINS
+          valueFrom:
+            configMapKeyRef:
+              name: backend
+              key: CORS_ALLOWED_ORIGINS
 ---
 apiVersion: v1
 kind: Service

--- a/src/main/java/co/javeriana/dw/organizapp/config/CorsConfig.java
+++ b/src/main/java/co/javeriana/dw/organizapp/config/CorsConfig.java
@@ -6,27 +6,33 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 public class CorsConfig {
 
-    @Value("${cors.allowed-origins:http://localhost:4200}")
+    /**
+     * Orígenes permitidos. Sobreescribible con CORS_ALLOWED_ORIGINS en K8s.
+     * Spring Boot relaxed binding: CORS_ALLOWED_ORIGINS → cors.allowed-origins
+     */
+    @Value("${cors.allowed-origins:http://localhost:4200,https://grupo14.inphotech.co}")
     private String allowedOriginsRaw;
 
     @Bean
-    public CorsFilter corsFilter() {
+    public CorsConfigurationSource corsConfigurationSource() {
         List<String> origins = Arrays.asList(allowedOriginsRaw.split(","));
 
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(origins);
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept", "Origin"));
+        configuration.setExposedHeaders(List.of("Authorization"));
         configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
-        return new CorsFilter(source);
+        return source;
     }
 }

--- a/src/main/java/co/javeriana/dw/organizapp/config/SecurityConfig.java
+++ b/src/main/java/co/javeriana/dw/organizapp/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import co.javeriana.dw.organizapp.security.JwtAuthFilter;
 import co.javeriana.dw.organizapp.security.UserDetailsServiceImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -14,6 +15,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
@@ -36,8 +39,11 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        // Preflight CORS — siempre libre
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // TODO: Entrega Final — reemplazar por anyRequest().authenticated()
                         .anyRequest().permitAll()
                 )

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,4 +7,5 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 jwt.secret=${JWT_SECRET:clave-desarrollo-no-usar-en-produccion-debe-ser-larga-minimo-64-caracteres-aqui}
 jwt.expiration=${JWT_EXPIRATION:86400000}
 
-cors.allowed-origins=${CORS_ORIGINS:http://localhost:4200}
+# CORS — sobreescribible con CORS_ALLOWED_ORIGINS en K8s
+cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:4200,https://grupo14.inphotech.co}


### PR DESCRIPTION
- CorsConfig: CorsFilter -> CorsConfigurationSource (usado por .cors(withDefaults()))
- SecurityConfig: agrega .cors(withDefaults()) + OPTIONS /** permitido
- application.properties: cors.allowed-origins incluye origen de produccion
- k8s: CORS_ALLOWED_ORIGINS en ConfigMap y container env

Causa raiz: SecurityFilterChain nunca llamaba .cors() -> Spring Security rechazaba preflight OPTIONS antes de consultar la config CORS.